### PR TITLE
Add support for Prime X470-Pro

### DIFF
--- a/asus-wmi-sensors.c
+++ b/asus-wmi-sensors.c
@@ -30,6 +30,7 @@ MODULE_VERSION("3");
 #define CROSSHAIR_7 "ROG CROSSHAIR VII HERO"
 #define CROSSHAIR_7_WIFI "ROG CROSSHAIR VII HERO (WI-FI)"
 #define ZENITH_EXTREME "ROG ZENITH EXTREME"
+#define PRIME_X470_PRO "PRIME X470-PRO"
 
 #define METHODID_SENSOR_GET_VALUE     		0x52574543
 #define METHODID_SENSOR_UPDATE_BUFFER     	0x51574543
@@ -541,7 +542,8 @@ static int is_board_supported(void) {
 			strcmp(board_name, CROSSHAIR_6_WIFI) == 0 ||
 			strcmp(board_name, CROSSHAIR_6) == 0 ||
 			strcmp(board_name, CROSSHAIR_6_EXTREME) == 0 ||
-			strcmp(board_name, ZENITH_EXTREME) == 0))) {
+			strcmp(board_name, ZENITH_EXTREME) == 0 ||
+			strcmp(board_name, PRIME_X470_PRO) == 0))) {
 
 			pr_info("asuswmisensors: Supported board");
 			return 0;


### PR DESCRIPTION
Got this board a short while ago and have been scouring for means of reading the sensors, was very happy to find this :) then very sad to find out my board isn't supported :(.. Had to pop in a windows drive to see where HWinfo is getting it from, at least on my current bios version *(4602, most recent)* it's pulling from WMI.

I know a bit of C *(not that it really matters here :P)* but I dug around in the source and found how simple it was to try adding it, sure enough it works, everything seems to be detected properly and accurate.

```
% sensors
asuswmisensors-isa-0000
Adapter: ISA adapter
CPU Core Voltage:         +0.84 V
+12V Voltage:            +10.19 V
+5V Voltage:              +5.07 V
3VSB Voltage:             +3.36 V
CPU Fan:                  448 RPM
Chassis Fan 1:            399 RPM
Chassis Fan 2:            246 RPM
Chassis Fan 3:            425 RPM
AIO Pump:                 406 RPM
Water Pump:               351 RPM
CPU OPT:                  372 RPM
CPU Temperature:          +39.0°C
Motherboard Temperature:  +34.0°C
Chipset Temperature:      +52.0°C
Tsensor 1 Temperature:   +216.0°C

k10temp-pci-00c3
Adapter: PCI adapter
Tdie:         +39.2°C  (high = +70.0°C)
Tctl:         +49.2°C

amdgpu-pci-0b00
Adapter: PCI adapter
vddgfx:       +1.05 V
temp1:        +30.0°C  (crit = +89.0°C, hyst = -273.1°C)
power1:       12.00 W  (cap = 220.00 W)
```
I'm not sure what's up with the +12V though but that's a minor issue for me.

Regardless of whether you think this is worth merging thank you very much for the source.

Cheers