### PR TITLE
add support for ROG Strix B450-F Gaming

### DIFF
--- a/asus-wmi-sensors.c
+++ b/asus-wmi-sensors.c
@@ -34,6 +34,7 @@ MODULE_VERSION("3");
 #define PRIME_X470_PRO "PRIME X470-PRO"
 #define PRIME_X399_A "PRIME X399-A"
 #define STRIX_X399_E "ROG STRIX X399-E GAMING"
+#define STRIX_B450_F "ROG STRIX B450-F GAMING"
 #define PRO_WS_X570_ACE "Pro WS X570-ACE"
 #define PRIME_X570_PRO "PRIME X570-PRO"
 
@@ -552,6 +553,7 @@ static int is_board_supported(void) {
 			strcmp(board_name, PRIME_X399_A) == 0 ||
 			strcmp(board_name, PRIME_X470_PRO) == 0 ||
 			strcmp(board_name, STRIX_X399_E) == 0 ||
+			strcmp(board_name, STRIX_B450_F) == 0 ||
 			strcmp(board_name, PRO_WS_X570_ACE) == 0 ||
 			strcmp(board_name, PRIME_X570_PRO) == 0))) {
 


### PR DESCRIPTION
Works for me, only used on BIOS 2406

```
asuswmisensors: Vendor: ASUSTeK COMPUTER INC. Board: ROG STRIX B450-F GAMING BIOS version: 2406 WMI version: 2
```

```
asuswmisensors-isa-0000
Adapter: ISA adapter
CPU Core Voltage:         +0.80 V  
VPP MEM Voltage:          +2.46 V  
+12V Voltage:            +10.14 V  
+5V Voltage:              +4.99 V  
3VSB Voltage:             +3.29 V  
VBAT Voltage:             +3.16 V  
AVCC3 Voltage:            +3.29 V  
SB 1.05V Voltage:         +1.02 V  
CPU Core Voltage:         +0.00 V  
CPU SOC Voltage:          +0.00 V  
CPU Fan:                 2647 RPM
Chassis Fan 1:           1229 RPM
Chassis Fan 2:           1290 RPM
Chassis Fan 3:              0 RPM
AIO Pump:                   0 RPM
Water Pump:                 0 RPM
CPU OPT:                    0 RPM
CPU Temperature:          +45.0°C  
CPU Socket Temperature:   +42.0°C  
Motherboard Temperature:  +41.0°C  
Chipset Temperature:      +50.0°C  
Tsensor 1 Temperature:   +216.0°C  
CPU VRM Temperature:       +0.0°C  
CPU VRM Output Current:   +0.00 A 
```