### PR TITLE
Got ROG STRIX X470-F Gaming working

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Provides a Linux kernel module "asus_wmi_sensors" that provides sensor readouts 
 |Asus ROG Crosshair Hero VI Extreme | ?                    |
 |ROG STRIX B450-F GAMING            | 2406                 |
 |ROG STRIX B450-I GAMING            | 2406                 |
+|ROG STRIX B450-F GAMING            | 5007                 |
 |ROG STRIX X399-E GAMING            |                      |
 |ASUS Zenith Extreme                | 1607/1701            |
 |ASUS Zenith Extreme Alpha          | 0207                 |
@@ -30,7 +31,6 @@ Provides a Linux kernel module "asus_wmi_sensors" that provides sensor readouts 
 |Board                              |
 |-----------------------------------|
 |X570 boards (no WMI interface - use `nct6775` driver instead)|
-|ASUS ROG STRIX B450/X470|
 |Prime B450-Plus|
 |Prime X370-Pro|
 

--- a/asus-wmi-sensors.c
+++ b/asus-wmi-sensors.c
@@ -37,6 +37,7 @@ MODULE_VERSION("3");
 #define STRIX_B450_F "ROG STRIX B450-F GAMING"
 #define STRIX_B450_I "ROG STRIX B450-I GAMING"
 #define STRIX_X470_I "ROG STRIX X470-I GAMING"
+#define STRIX_X470_F "ROG STRIX X470-F GAMING"
 
 #define METHODID_SENSOR_GET_VALUE     		0x52574543
 #define METHODID_SENSOR_UPDATE_BUFFER     	0x51574543
@@ -555,7 +556,8 @@ static int is_board_supported(void) {
 			strcmp(board_name, STRIX_X399_E) == 0 ||
 			strcmp(board_name, STRIX_B450_F) == 0 ||
 			strcmp(board_name, STRIX_B450_I) == 0 ||
-			strcmp(board_name, STRIX_X470_I) == 0))) {
+			strcmp(board_name, STRIX_X470_I) == 0 ||
+			strcmp(board_name, STRIX_X470_F) == 0))) {
 
 			pr_info("asuswmisensors: Supported board");
 			return 0;


### PR DESCRIPTION
This works with my ROG STRIX x470-F Gaming + Ryzen 3700x.

What appears to work fine:
CPU Temperature
Motherboard Temperature
Chipset Temperature

CPU Fan
CPU OPT
Chasis Fan 1-3
AIO Pump
Water Pump

CPU Core Voltage
+5V Voltage
3VSB Voltage

The following are being reported, but I'm not sure if the values are
correct:

+12V Voltage => I'm only getting 10.08v
TSensor 1 Temperature => This is +200C

TSensor 1 seems odd, but is in line with the Example value in the
README.

Here an example output:

asuswmisensors-isa-0000
Adapter: ISA adapter
CPU Core Voltage:         +1.42 V
+12V Voltage:            +10.08 V
+5V Voltage:              +4.99 V
3VSB Voltage:             +3.33 V
CPU Fan:                  740 RPM
Chassis Fan 1:              0 RPM
Chassis Fan 2:            709 RPM
Chassis Fan 3:            760 RPM
AIO Pump:                   0 RPM
Water Pump:               864 RPM
CPU OPT:                  796 RPM
CPU Temperature:          +65.0°C
Motherboard Temperature:  +37.0°C
Chipset Temperature:      +50.0°C
Tsensor 1 Temperature:   +216.0°C