### PR TITLE
Enable ROG STRIX B450-E GAMING motherboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Provides a Linux kernel module "asus_wmi_sensors" that provides sensor readouts 
 |Asus ROG Crosshair Hero VI         | 6301                 |
 |Asus ROG Crosshair Hero VI (WiFi)  | 6302                 |
 |Asus ROG Crosshair Hero VI Extreme | ?                    |
+|ROG STRIX B450-E GAMING            | 2406                 |
 |ROG STRIX B450-F GAMING            | 2406                 |
 |ROG STRIX B450-I GAMING            | 2406                 |
 |ROG STRIX X470-F GAMING            | 5007                 |

--- a/asus-wmi-sensors.c
+++ b/asus-wmi-sensors.c
@@ -34,6 +34,7 @@ MODULE_VERSION("3");
 #define PRIME_X470_PRO "PRIME X470-PRO"
 #define PRIME_X399_A "PRIME X399-A"
 #define STRIX_X399_E "ROG STRIX X399-E GAMING"
+#define STRIX_B450_E "ROG STRIX B450-E GAMING"
 #define STRIX_B450_F "ROG STRIX B450-F GAMING"
 #define STRIX_B450_I "ROG STRIX B450-I GAMING"
 #define STRIX_X470_I "ROG STRIX X470-I GAMING"
@@ -554,6 +555,7 @@ static int is_board_supported(void) {
 			strcmp(board_name, PRIME_X399_A) == 0 ||
 			strcmp(board_name, PRIME_X470_PRO) == 0 ||
 			strcmp(board_name, STRIX_X399_E) == 0 ||
+			strcmp(board_name, STRIX_B450_E) == 0 ||
 			strcmp(board_name, STRIX_B450_F) == 0 ||
 			strcmp(board_name, STRIX_B450_I) == 0 ||
 			strcmp(board_name, STRIX_X470_I) == 0 ||


### PR DESCRIPTION
Most readings appear to work correctly, except some that are suspect:
* +12V Voltage
* CPU Core Voltage (2nd)
* CPU SOC Voltage
* Tsensor 1 Temperature
* CPU VRM Temperature
* CPU VRM Output Current

Is there any further tweaking you would recommend for these odd readings?

Example output:
```
asuswmisensors-isa-0000
Adapter: ISA adapter
CPU Core Voltage:         +1.09 V
VPP MEM Voltage:          +2.48 V
+12V Voltage:            +10.03 V
+5V Voltage:              +5.07 V
3VSB Voltage:             +3.31 V
VBAT Voltage:             +3.27 V
AVCC3 Voltage:            +3.31 V
SB 1.05V Voltage:         +1.04 V
CPU Core Voltage:         +0.00 V
CPU SOC Voltage:          +0.00 V
CPU Fan:                  460 RPM
Chassis Fan 1:            901 RPM
Chassis Fan 2:            677 RPM
Chassis Fan 3:              0 RPM
AIO Pump:                   0 RPM
Water Pump:                 0 RPM
CPU OPT:                    0 RPM
CPU Temperature:          +50.0°C
CPU Socket Temperature:   +36.0°C
Motherboard Temperature:  +47.0°C
Chipset Temperature:      +43.0°C
Tsensor 1 Temperature:   +216.0°C
CPU VRM Temperature:       +0.0°C
CPU VRM Output Current:   +0.00 A
```

dmidecode output:
```
# dmidecode 3.2
Getting SMBIOS data from sysfs.
SMBIOS 3.2.0 present.
Table at 0x000E68E0.

Handle 0x0000, DMI type 0, 26 bytes
BIOS Information
        Vendor: American Megatrends Inc.
        Version: 2501
        Release Date: 07/12/2019
        Address: 0xF0000
        Runtime Size: 64 kB
        ROM Size: 16 MB
        Characteristics:
                PCI is supported
                APM is supported
                BIOS is upgradeable
                BIOS shadowing is allowed
                Boot from CD is supported
                Selectable boot is supported
                BIOS ROM is socketed
                EDD is supported
                5.25"/1.2 MB floppy services are supported (int 13h)
                3.5"/720 kB floppy services are supported (int 13h)
                3.5"/2.88 MB floppy services are supported (int 13h)
                Print screen service is supported (int 5h)
                8042 keyboard services are supported (int 9h)
                Serial services are supported (int 14h)
                Printer services are supported (int 17h)
                ACPI is supported
                USB legacy is supported
                BIOS boot specification is supported
                Targeted content distribution is supported
                UEFI is supported
        BIOS Revision: 5.13

Handle 0x0001, DMI type 1, 27 bytes
System Information
        Manufacturer: System manufacturer
        Product Name: System Product Name
        Version: System Version
        Serial Number: System Serial Number
        UUID: 4f622c28-41a1-6ca1-7084-049226c36fff
        Wake-up Type: Power Switch
        SKU Number: SKU
        Family: To be filled by O.E.M.

Handle 0x0002, DMI type 2, 15 bytes
Base Board Information
        Manufacturer: ASUSTeK COMPUTER INC.
        Product Name: ROG STRIX B450-E GAMING
        Version: Rev 1.xx
        Serial Number: 181139673700420
        Asset Tag: Default string
        Features:
                Board is a hosting board
                Board is replaceable
        Location In Chassis: Default string
        Chassis Handle: 0x0003
        Type: Motherboard
        Contained Object Handles: 0

[...]
```
