### PR TITLE
Correct NixOS instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ An ebuild is available in gyakovlev's overlay. https://github.com/gyakovlev/gent
 Available as a package since 20.03 release, could be enabled with:
 
 ```
-boot.extraModulePackages = [
-    pkgs.asus-wmi-sensors
+boot.extraModulePackages = with config.boot.kernelPackages; [
+    asus-wmi-sensors
 ];
 ```
 


### PR DESCRIPTION
`asus-wmi-sensors` is not a regular top-level package, but scoped within the kernel packages.